### PR TITLE
Add proxyListen talk mode

### DIFF
--- a/lib/src/model/audio.dart
+++ b/lib/src/model/audio.dart
@@ -4,20 +4,18 @@ enum AudioCodec { celtAlpha, ping, speex, celtBeta, opus }
 
 AudioCodec assertNotPing(AudioCodec codec) {
   if (codec == AudioCodec.ping) {
-    throw new ArgumentError(
-        'A real AudioCodec is expected at this point, which AudioCodec.ping is not!');
+    throw new ArgumentError('A real AudioCodec is expected at this point, which AudioCodec.ping is not!');
   } else {
     return codec;
   }
 }
 
-enum TalkMode { normal, whisperToChannel, whisperToUser }
+enum TalkMode { normal, whisperToChannel, whisperToUser, proxyListen }
 
 class PositionalInformation {
   final double x, y, z;
 
-  const PositionalInformation(
-      {required this.x, required this.y, required this.z});
+  const PositionalInformation({required this.x, required this.y, required this.z});
 
   operator [](int index) {
     switch (index) {


### PR DESCRIPTION
This adds a `proxyListen` entry to the `TalkMode` enum for clients receiving audio using the new Mumble 1.4 proxy listener features.